### PR TITLE
Broken pipe 상황 삭제

### DIFF
--- a/examples/ex01/try_me.c
+++ b/examples/ex01/try_me.c
@@ -12,7 +12,6 @@ void register_catch(void)
 {
     signal(SIGSEGV, &_on_catch); //11
     signal(SIGFPE, &_on_catch); //8
-    signal(SIGPIPE, &_on_catch); //13
     signal(SIGABRT, &_on_catch); //6
     signal(SIGBUS, &_on_catch); //10
 }

--- a/examples/ex02/catch_me.c
+++ b/examples/ex02/catch_me.c
@@ -13,7 +13,6 @@ int catch_me(int (*try_action)(void), void (*catch_action)(int))
 {
     signal(SIGSEGV, &_on_catch); //11
     signal(SIGFPE, &_on_catch); //8
-    signal(SIGPIPE, &_on_catch); //13
     signal(SIGABRT, &_on_catch); //6
     signal(SIGBUS, &_on_catch); //10
 

--- a/tester/ex01/test_ex01.sh
+++ b/tester/ex01/test_ex01.sh
@@ -19,8 +19,7 @@ fi
 # 8: Floating point error
 # 10: Bus error
 # 11: Segmentation fault
-# 13: Broken pipe
-ARR='6 8 10 11 13'
+ARR='6 8 10 11'
 idx=1
 for i in $ARR
 do

--- a/tester/ex02/test_ex02.sh
+++ b/tester/ex02/test_ex02.sh
@@ -26,8 +26,7 @@ fi
 # 8: Floating point error
 # 10: Bus error
 # 11: Segmentation fault
-# 13: Broken pipe
-ARR='6 8 10 11 13'
+ARR='6 8 10 11'
 idx=1
 for i in $ARR
 do


### PR DESCRIPTION
일반적으로 SIGPIPE는 fd작업을 하는게 아닌 이상, 자주 볼 수 있는 예외가 아니기 때문에, 이 시그널에 대해 공부하는 것은 약간 규모가 커질 수 있다고 판단이 됨.